### PR TITLE
Clean up var names + create separate resource groups 

### DIFF
--- a/cmd/backend.go
+++ b/cmd/backend.go
@@ -82,6 +82,13 @@ func initWorkspace() error {
 	// set the location of the state File
 	planParams.State = &stateFileName
 
+	// Set the resource group name to `cluster name`-`cluster owner`-rb
+	cluster.TfAzureVars.ResourceGroup = fmt.Sprintf(
+		"%s-%s-rb",
+		cluster.TfConfigVars.ClusterName,
+		cluster.TfConfigVars.ClusterOwner,
+	)
+
 	return nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/trawler/cna-installer/pkg/terraform"
@@ -81,4 +83,33 @@ func getHomeDir() (string, error) {
 		return "", fmt.Errorf("cannot get home dir. is $HOME set in your environment? \n%v", err)
 	}
 	return home, nil
+}
+
+// Agent Pool Name must start with a lowercase letter, have max length of 12, and only have characters a-z0-9.
+// This function takes the cluster's name and formats a valid agent pool name.
+func sanitizeAgentPoolName(cName string, cOwner string) (string, error) {
+	rawName := fmt.Sprintf("%s-%s", cOwner, cName)
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		return "", fmt.Errorf("%v", err)
+	}
+
+	splitArray := reg.Split(rawName, -1)
+	maxLength := 12
+	tmpName := ""
+	addon := ""
+
+	for _, element := range splitArray {
+		// don't capitalize first letter
+		addon = strings.ToLower(element)
+
+		// limit output to maxLength
+		if len(tmpName+string(element)) <= maxLength {
+			tmpName = tmpName + addon
+		} else {
+			break
+		}
+
+	}
+	return tmpName, nil
 }

--- a/cna-installer.example.yaml
+++ b/cna-installer.example.yaml
@@ -1,12 +1,13 @@
 config:
-  clusterName: dev
+  clusterName: dev-cluster1
   clusterOwner: myuser
-  clusterVersion: 1.14.3
-  baseDomain: dev.myuser.example.com
+  clusterVersion: 1.15.4
+  baseDomain: example.com
 
 azure:
   agentCount: 3
   agentOSDiskSizeGB: 30
   agentOSType: Linux
   agentVMSize: Standard_DS2_v2
+  availabilityZone: francecentral
   publicKey: ~/.ssh/id_rsa.pub

--- a/data/terraform/aks/aks.tf
+++ b/data/terraform/aks/aks.tf
@@ -18,11 +18,11 @@ resource "azurerm_resource_group" "k8s" {
 }
 
 resource "azurerm_kubernetes_cluster" "k8s" {
-  name                = var.k8s_cluster_name
+  name                = format("%s-%s", var.cluster_owner, var.k8s_cluster_name)
   location            = azurerm_resource_group.k8s.location
   resource_group_name = azurerm_resource_group.k8s.name
   kubernetes_version  = var.k8s_version
-  dns_prefix          = var.dns_prefix
+  dns_prefix          = var.cluster_owner
 
   linux_profile {
     admin_username = "ubuntu"
@@ -33,7 +33,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   agent_pool_profile {
     count           = var.agent_count
-    name            = var.k8s_cluster_name
+    name            = var.agent_pool_name
     vm_size         = var.agent_vm_size
     os_type         = var.agent_os_type
     os_disk_size_gb = var.agent_os_disk_size_gb

--- a/data/terraform/aks/variables.tf
+++ b/data/terraform/aks/variables.tf
@@ -11,7 +11,6 @@ variable "k8s_resource_group_name" {
 variable "az_location" {
   description = "(Required) The location where the Managed Kubernetes Cluster should be created. Changing this forces a new resource to be created."
   type        = "string"
-  default     = "francecentral"
 }
 
 variable "k8s_cluster_name" {
@@ -27,8 +26,8 @@ EOF
   type        = "string"
 }
 
-variable "dns_prefix" {
-  description = "(Required) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created."
+variable "cluster_owner" {
+  description = "(Required) the user or group that created the cluster. Changing this forces a new resource to be created."
   type        = "string"
 }
 
@@ -50,8 +49,8 @@ variable "agent_count" {
 (Required) Number of Agents (VMs) in the Pool. Possible values must be in
 the range of 1 to 100 (inclusive). Defaults to 1.
 EOF
-
-  default = 1
+  type        = "string"
+  default     = 1
 }
 
 variable "agent_os_type" {
@@ -65,6 +64,12 @@ EOF
 
 variable "agent_os_disk_size_gb" {
   description = "(Optional) The Agent Operating System disk size in GB. "
+}
+
+variable "agent_pool_name" {
+  description = <<EOF
+ (Required) Unique name of the Agent Pool Profile in the context of the Subscription and Resource Group. Changing this forces a new resource to be created.
+EOF
 }
 
 variable "azure_client_id" {

--- a/data/terraform/tf-backend/main.tf
+++ b/data/terraform/tf-backend/main.tf
@@ -2,17 +2,17 @@ provider "azurerm" {
   version = "1.35.0"
 }
 
-resource "azurerm_resource_group" "k8s" {
+resource "azurerm_resource_group" "cna-backend" {
   name     = var.k8s_resource_group_name
   location = var.az_location
 }
 
 
 // Azure terraform backend storage account
-resource "azurerm_storage_account" "tf-backend" {
-  name                     = format("%stfstorage", var.dns_prefix)
-  resource_group_name      = azurerm_resource_group.k8s.name
-  location                 = azurerm_resource_group.k8s.location
+resource "azurerm_storage_account" "tf-cna-backend" {
+  name                     = format("%stfstorage", var.cluster_owner)
+  resource_group_name      = azurerm_resource_group.cna-backend.name
+  location                 = azurerm_resource_group.cna-backend.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -22,7 +22,7 @@ resource "azurerm_storage_account" "tf-backend" {
 }
 
 resource "azurerm_storage_container" "tf-storage-container" {
-  name                  = "terraform-tfstate"
-  storage_account_name  = azurerm_storage_account.tf-backend.name
+  name                  = "cna-tfstate"
+  storage_account_name  = azurerm_storage_account.tf-cna-backend.name
   container_access_type = "private"
 }

--- a/data/terraform/tf-backend/variables.tf
+++ b/data/terraform/tf-backend/variables.tf
@@ -6,7 +6,6 @@ variable "k8s_resource_group_name" {
 variable "az_location" {
   description = "(Required) The location where the Managed Kubernetes Cluster should be created. Changing this forces a new resource to be created."
   type        = "string"
-  default     = "francecentral"
 }
 
 variable "k8s_cluster_name" {
@@ -14,7 +13,7 @@ variable "k8s_cluster_name" {
   type        = "string"
 }
 
-variable "dns_prefix" {
+variable "cluster_owner" {
   description = "(Required) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created."
   type        = "string"
 }

--- a/pkg/terraform/config.go
+++ b/pkg/terraform/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	"gopkg.in/yaml.v2"
 )
@@ -48,20 +49,21 @@ func GetEnvVars(c *Cluster) error {
 		return fmt.Errorf("clusterOwner is not set")
 	}
 
-	c.TfAzureVars.ResourceGroup = fmt.Sprintf("%s_%s", c.TfConfigVars.ClusterName, c.TfConfigVars.ClusterOwner)
-
 	prefix := "TF_VAR"
 	os.Setenv(fmt.Sprintf("%s_base_domain", prefix), c.TfConfigVars.BaseDomain)
-	os.Setenv(fmt.Sprintf("%s_dns_prefix", prefix), c.TfConfigVars.ClusterOwner)
+	os.Setenv(fmt.Sprintf("%s_cluster_owner", prefix), c.TfConfigVars.ClusterOwner)
 	os.Setenv(fmt.Sprintf("%s_k8s_cluster_name", prefix), c.TfConfigVars.ClusterName)
 	os.Setenv(fmt.Sprintf("%s_k8s_version", prefix), c.TfConfigVars.ClusterVersion)
 
-	os.Setenv(fmt.Sprintf("%s_k8s_resource_group_name", prefix), c.TfAzureVars.ResourceGroup)
+	os.Setenv(fmt.Sprintf("%s_agent_count", prefix), strconv.Itoa(c.TfAzureVars.AgentCount))
 	os.Setenv(fmt.Sprintf("%s_agent_os_disk_size_gb", prefix), c.TfAzureVars.OSDisksize)
+	os.Setenv(fmt.Sprintf("%s_agent_pool_name", prefix), c.TfAzureVars.AgentPoolName)
 	os.Setenv(fmt.Sprintf("%s_agent_vm_size", prefix), c.TfAzureVars.VMSize)
-	os.Setenv(fmt.Sprintf("%s_public_key_file", prefix), c.TfAzureVars.PublicKeyFile)
+	os.Setenv(fmt.Sprintf("%s_az_location", prefix), c.TfAzureVars.AvailabilityZone)
 	os.Setenv(fmt.Sprintf("%s_azure_client_id", prefix), auth.ClientID)
 	os.Setenv(fmt.Sprintf("%s_azure_client_secret", prefix), auth.ClientSecret)
+	os.Setenv(fmt.Sprintf("%s_k8s_resource_group_name", prefix), c.TfAzureVars.ResourceGroup)
+	os.Setenv(fmt.Sprintf("%s_public_key_file", prefix), c.TfAzureVars.PublicKeyFile)
 
 	return nil
 }

--- a/pkg/terraform/types.go
+++ b/pkg/terraform/types.go
@@ -18,7 +18,8 @@ type TfConfigVars struct {
 
 // TfAzureVars comment
 type TfAzureVars struct {
-	AgentCount       int    `json:",inline" yaml:"agentCount,omitempty"`
+	AgentCount       int `json:",inline" yaml:"agentCount,omitempty"`
+	AgentPoolName    string
 	AvailabilityZone string `json:",inline" yaml:"availabilityZone,omitempty"`
 	ClientID         string `json:",inline" yaml:"clientID,omitempty"`
 	ClientSecret     string `json:",inline" yaml:"clientSecret,omitempty"`


### PR DESCRIPTION
- Use separate resource groups for remote backend and aks (Fixes #13)
- Format AgentPoolName per Azurerm naming constraints (https://github.com/terraform-providers/terraform-provider-azurerm/blob/0aedd7793c9abadccf74691d04fb71cc611f7963/azurerm/helpers/validate/kubernetes.go#L33)
- Fix an issue whereby agentCount and availabilityZone weren't sent to the terraform backend, because there were not exported in the installer.