### PR TITLE
Add noop (dry-run) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Available Commands:
 Flags:
       --config string   config file (default is $HOME/.cna-installer.yaml)
   -h, --help            help for cna-installer
+      --noop            dry-run (do not perform changes)
+  -v, --verbose         verbose output
 
 Use "cna-installer [command] --help" for more information about a command.
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,13 +13,17 @@ import (
 	"github.com/trawler/cna-installer/pkg/terraform"
 )
 
+// command flags
 var cfgFile string
-var cluster *terraform.Cluster
-var err error
-var logDir string
+var noop bool
+var verbose bool
 
+var cluster *terraform.Cluster
+var logDir string
 var stateFileName string
 var tf *terraform.Executor
+
+var err error
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -39,6 +43,9 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().BoolVarP(&noop, "noop", "", false, "dry-run (do not perform changes)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cna-installer.yaml)")
 }
 
@@ -52,7 +59,6 @@ func initConfig() {
 		}
 		cfgFile = path.Join(home, ".cna-installer.yaml")
 	}
-
 	// Parse the config file into a Cluster struct
 	cluster, err = terraform.ParseConfigFile(cfgFile)
 	if err != nil {

--- a/cmd/tf.go
+++ b/cmd/tf.go
@@ -30,14 +30,16 @@ func tfRun() error {
 		return fmt.Errorf("%v", err)
 	}
 
-	// Run terraform apply
-	apply := tf.Apply(planParams)
-	apply.Initialise()
+	// Run terraform apply if noop is false or is not set
+	if noop == false {
+		// Run terraform apply
+		apply := tf.Apply(planParams)
+		apply.Initialise()
 
-	if err = apply.Run(); err != nil {
-		return fmt.Errorf("%v", err)
+		if err = apply.Run(); err != nil {
+			return fmt.Errorf("%v", err)
+		}
 	}
-
 	return nil
 }
 
@@ -47,12 +49,27 @@ func tfDestroy() error {
 		return fmt.Errorf("%v", err)
 	}
 
-	destroy := tf.Destroy(planParams)
-	destroy.Initialise()
+	// Run terraform destroy if noop is false or is not set
+	if noop == true {
+		// run terraform plan -destroy
+		planParams.AutoApprove = false
+		planParams.Destroy = true
 
-	if err = destroy.Run(); err != nil {
-		return fmt.Errorf("%v", err)
+		planParams.Opts()
+		plan := tf.Plan(planParams)
+		plan.Initialise()
+
+		if err = plan.Run(); err != nil {
+			return fmt.Errorf("%v", err)
+		}
+	} else {
+		// run terraform destroy -auto-approve
+		planParams.AutoApprove = true
+		destroy := tf.Destroy(planParams)
+		destroy.Initialise()
+		if err = destroy.Run(); err != nil {
+			return fmt.Errorf("%v", err)
+		}
 	}
-
 	return nil
 }

--- a/pkg/terraform/exec.go
+++ b/pkg/terraform/exec.go
@@ -88,11 +88,6 @@ func (cli *Executor) Apply(params *TfPlanParams) *TfAction {
 
 // Destroy Action
 func (cli *Executor) Destroy(params *TfPlanParams) *TfAction {
-	// because we are using the same param structure for both plan & apply,
-	// we need set auto-approve to true for apply actions
-	if params.AutoApprove == false {
-		params.AutoApprove = true
-	}
 	return &TfAction{
 		action:        "destroy",
 		bin:           cli,


### PR DESCRIPTION
If --noop is set, installer will skip `terraform apply`.
When destroying a cluster, setting `--noop` will show the output of `terraform apply -destroy` (destroy preview).

This PR also adds a `verbose` flag to be used when refactoring output.